### PR TITLE
Update PUBLIC_URL and CNAME for metadata-quality.mjanez.dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "deploy": "gh-pages -d build",
     "start": "react-scripts start",
     "start-local": "set BROWSER=none && set PORT=3000 && react-scripts start",
-    "build": "cross-env PUBLIC_URL=/metadata-quality-react react-scripts build",
+    "build": "cross-env PUBLIC_URL=/ react-scripts build",
     "build:docker": "react-scripts build",
     "build-local": "npm run build && npx serve -s build -l 8000",
     "test": "react-scripts test",

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,0 +1,1 @@
+metadata-quality.mjanez.dev


### PR DESCRIPTION
Deployment configuration updates:
* Changed the `PUBLIC_URL` in the `build` script of `package.json` from `/metadata-quality-react` to `/`, which affects how the app resolves asset paths during deployment.
* Added a `CNAME` file in the `public` directory to set the custom domain to `metadata-quality.mjanez.dev` for GitHub Pages deployment.